### PR TITLE
Move gulp dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {
-    "gulp": "^4.0.2",
-    "gulp-minify": "^3.1.0"
+  "dependencies": {},
+  "devDependencies": {
+     "gulp": "^4.0.2",
+     "gulp-minify": "^3.1.0"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Hello!

The gulp dependencies should be into the development dependencies section in ```package.json``` to avoid posible issues in some packagers, like webpack.

Cheers